### PR TITLE
[MNM-28]feat: chip,formatTokoreaTime구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
+        "date-fns": "^4.1.0",
         "framer-motion": "^11.11.17",
         "next": "^14.2.18",
         "react": "^18",
@@ -1935,6 +1936,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
+    "date-fns": "^4.1.0",
     "framer-motion": "^11.11.17",
     "next": "^14.2.18",
     "react": "^18",

--- a/src/app/(testPages)/date/page.tsx
+++ b/src/app/(testPages)/date/page.tsx
@@ -16,17 +16,20 @@ export default function page() {
 
       {/* 칩 더미 */}
       <div className="flex items-center justify-between gap-2">
-        <Chip type="state" bgColor="yellow" textColor="black">
+        <Chip type="state" bgColor="bg-yellow-primary" textColor="black">
           {koreanMinute}
         </Chip>
-        <Chip type="default" bgColor="black" textColor="white">
+        <Chip type="default" bgColor="bg-black" textColor="text-white">
           글자 수 테스트 1231.
         </Chip>
-        <Chip type="time" bgColor="white" textColor="yellow">
+        <Chip type="time" bgColor="bg-white" textColor="text-yellow-primary">
           {koreanTime}
         </Chip>
-        <Chip type="default" bgColor="black" textColor="white" shadow={true}>
+        <Chip type="default" bgColor="bg-black" textColor="text-green-400" shadow={true}>
           shadow
+        </Chip>
+        <Chip type="time" fontSize="text-lg" fontWeight="font-bold">
+          칠칠드런드런
         </Chip>
       </div>
     </div>

--- a/src/app/(testPages)/date/page.tsx
+++ b/src/app/(testPages)/date/page.tsx
@@ -1,0 +1,34 @@
+import Chip from "@/components/chip";
+import { formatToKoreanTime } from "@/utils/date";
+
+export default function page() {
+  const serverData = {
+    createAt: "2024-11-27T15:30:00Z",
+  };
+  // dateString 예시: "yyyy년 MM월 dd일 HH시 mm분"
+  const koreanTime = formatToKoreanTime(serverData.createAt, "MM월 dd일");
+  const koreanMinute = formatToKoreanTime(serverData.createAt, "HH : mm");
+
+  return (
+    <div className="flex h-[100vh] flex-col items-center justify-center">
+      <div className="border-1 bg-yellow flex border-black">{koreanTime}</div>
+      <div>{koreanMinute}</div>
+
+      {/* 칩 더미 */}
+      <div className="flex items-center justify-between gap-2">
+        <Chip type="state" bgColor="yellow" textColor="black">
+          {koreanMinute}
+        </Chip>
+        <Chip type="default" bgColor="black" textColor="white">
+          글자 수 테스트 1231.
+        </Chip>
+        <Chip type="time" bgColor="white" textColor="yellow">
+          {koreanTime}
+        </Chip>
+        <Chip type="default" bgColor="black" textColor="white" shadow={true}>
+          shadow
+        </Chip>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(testPages)/progressbar/page.tsx
+++ b/src/app/(testPages)/progressbar/page.tsx
@@ -5,6 +5,7 @@ export default function Page() {
     <div className="flex h-[100vh] items-center justify-center">
       <div className="w-[200px]">
         <Progressbar now={10} max={20} />
+        <div>프로그레스바</div>
       </div>
     </div>
   );

--- a/src/components/chip.tsx
+++ b/src/components/chip.tsx
@@ -2,13 +2,15 @@ import { ChipProps } from "@/types/components/chip";
 
 export default function Chip({
   type,
-  bgColor = "yellow",
-  textColor = "black",
+  bgColor = "bg-yellow-500", // Tailwind CSS 클래스 직접 사용
+  textColor = "text-black",
   shadow = false,
+  fontSize = "text-sm", // 기본 폰트 사이즈
+  fontWeight = "font-medium", // 기본 폰트 굵기
   children,
 }: ChipProps) {
-  // 기본 스타일.
-  const baseClass = "flex items-center justify-center px-2 py-1 text-sm font-medium border";
+  // 기본 스타일
+  const baseClass = "flex items-center justify-center px-2 py-1 border";
 
   // 타입별 rounded 조정
   const roundedClass =
@@ -18,25 +20,13 @@ export default function Chip({
         ? "rounded-xl" // time 칩은 약간 둥글게
         : "rounded-md"; // default 칩은 살짝 둥글게
 
-  // 동적 스타일 - 배경색
-  const bgClass =
-    bgColor === "yellow" ? "bg-yellow-primary" : bgColor === "black" ? "bg-black" : "bg-white"; // 기본값 white
-
-  // 동적 스타일 - 텍스트 색
-  const textClass =
-    textColor === "white"
-      ? "text-white"
-      : textColor === "yellow"
-        ? "text-yellow-primary"
-        : "text-black"; // 기본값 black
-
   // 그림자 여부
   const shadowClass = shadow ? "shadow-xl" : "";
 
-  // 선택된 상태 스타일
-
   return (
-    <div className={`${baseClass} ${roundedClass} ${bgClass} ${textClass} ${shadowClass}`}>
+    <div
+      className={`${baseClass} ${roundedClass} ${bgColor} ${textColor} ${shadowClass} ${fontSize} ${fontWeight}`}
+    >
       {children}
     </div>
   );

--- a/src/components/chip.tsx
+++ b/src/components/chip.tsx
@@ -1,0 +1,43 @@
+import { ChipProps } from "@/types/components/chip";
+
+export default function Chip({
+  type,
+  bgColor = "yellow",
+  textColor = "black",
+  shadow = false,
+  children,
+}: ChipProps) {
+  // 기본 스타일.
+  const baseClass = "flex items-center justify-center px-2 py-1 text-sm font-medium border";
+
+  // 타입별 rounded 조정
+  const roundedClass =
+    type === "state"
+      ? "rounded-full" // state 칩은 완전 둥글게
+      : type === "time"
+        ? "rounded-xl" // time 칩은 약간 둥글게
+        : "rounded-md"; // default 칩은 살짝 둥글게
+
+  // 동적 스타일 - 배경색
+  const bgClass =
+    bgColor === "yellow" ? "bg-yellow-primary" : bgColor === "black" ? "bg-black" : "bg-white"; // 기본값 white
+
+  // 동적 스타일 - 텍스트 색
+  const textClass =
+    textColor === "white"
+      ? "text-white"
+      : textColor === "yellow"
+        ? "text-yellow-primary"
+        : "text-black"; // 기본값 black
+
+  // 그림자 여부
+  const shadowClass = shadow ? "shadow-xl" : "";
+
+  // 선택된 상태 스타일
+
+  return (
+    <div className={`${baseClass} ${roundedClass} ${bgClass} ${textClass} ${shadowClass}`}>
+      {children}
+    </div>
+  );
+}

--- a/src/types/components/chip.d.ts
+++ b/src/types/components/chip.d.ts
@@ -1,0 +1,9 @@
+export type ChipType = "state" | "time" | "default"; // 칩 종류.
+
+export interface ChipProps {
+  type: ChipType; // 칩 종류 선택
+  bgColor?: "white" | "black" | "yellow";
+  textColor?: "white" | "black" | "yellow";
+  shadow?: boolean; // 그림자 여부
+  children: React.ReactNode; // 칩 내용
+}

--- a/src/types/components/chip.d.ts
+++ b/src/types/components/chip.d.ts
@@ -2,8 +2,10 @@ export type ChipType = "state" | "time" | "default"; // 칩 종류.
 
 export interface ChipProps {
   type: ChipType; // 칩 종류 선택
-  bgColor?: "white" | "black" | "yellow";
-  textColor?: "white" | "black" | "yellow";
+  bgColor?: string;
+  textColor?: string;
   shadow?: boolean; // 그림자 여부
+  fontSize?: string;
+  fontWeight?: string; // 기본 폰트 굵기
   children: React.ReactNode; // 칩 내용
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,12 @@
+import { format, parseISO } from "date-fns";
+import { ko } from "date-fns/locale";
+
+// 한국 시간으로 변환하는 함수.
+export const formatToKoreanTime = (isoDate: string, dateString: string) => {
+  // ISO 형식의 날짜를 Date 객체로 변환
+  const date = parseISO(isoDate);
+
+  // 한국 표준시 기준 포맷 (yyyy년 MM월 dd일 HH:mm:ss)
+  // dateString 예시: "yyyy년 MM월 dd일 HH시 mm분"
+  return format(date, dateString, { locale: ko });
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,9 @@ const config: Config = {
       tablet: "768px",
     },
     extend: {
+      colors: {
+        "yellow-primary": "#FFE55D",
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic": "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",


### PR DESCRIPTION
## #️⃣연관된 이슈

MNM-28

## 📝작업 내용

### feat: 
### chip 구현 (인자가 많으니 공용컴포넌트 사용법을 참고해주세요

###  formatToKoreanTime 

 UTC -> Korea 시간으로 변경 및 yyyy년 ~~월 이런식으로 사용 가능합니다. 물론 월 ,일만 , 일,시간만도 사용 가능합니다.
--- 
### Style:
### tailwind 기본 속성에 yellow-primary 넣었습니다.(디자이너님 선택 색상)
ex) text-yellow-primary , bg-yellow-primary


### 스크린샷 (선택)
![스크린샷 2024-11-27 오후 4 12 26](https://github.com/user-attachments/assets/84e2c4a0-1eae-433c-9883-f196e9a958ea)

### 공용컴포넌트 사용법

https://wild-egg-9ad.notion.site/99846cb28a9d40ca869a0e86113fddb0
