### PR TITLE
[MNM-39] refactor: button

### DIFF
--- a/src/app/(testPages)/button/page.tsx
+++ b/src/app/(testPages)/button/page.tsx
@@ -1,24 +1,33 @@
 import Button from "@/components/Button/Button";
-import LinkButton from "@/components/Button/LinkButton";
 
 export default function ButtonTest() {
   return (
-    <>
-      <Button variant="primary" />
-      <Button variant="secondary" />
-      <Button variant="tertiary" />
-      <Button variant="disabled" />
-
-      <div className="w-24">
-        <Button variant="primary" size="small" />
-        <Button variant="secondary" size="small" />
-        <Button variant="tertiary" size="small" />
-        <Button variant="disabled" size="small" />
+    <div className="flex w-full flex-col gap-2 pt-2">
+      <Button color="yellow">노란 버튼</Button>
+      <Button color="orange">주황 버튼</Button>
+      <div className="flex w-24 flex-col gap-2">
+        <Button color="red" size="small">
+          빨간 버튼
+        </Button>
+        <Button color="disabled" size="small">
+          disabled button
+        </Button>
+        <Button color="yellow" size="small" isFilled={false}>
+          노란 버튼
+        </Button>
+        <Button color="orange" size="small" isFilled={false}>
+          주황 버튼
+        </Button>
       </div>
+      <Button color="red" isFilled={false}>
+        빨간 버튼
+      </Button>
+      <Button color="disabled" isFilled={false}>
+        disabled button
+      </Button>
 
-      <div>
-        <LinkButton href="/modal">모달 페이지 이동</LinkButton>
-      </div>
-    </>
+      <Button className="bg-gray-400 text-black">커스텀 회색 버튼</Button>
+      <Button className="bg-purple-300 text-cyan-400">커스텀 보라색 버튼</Button>
+    </div>
   );
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,14 +1,13 @@
-import { ButtonProps } from "@/types/components/button";
-import React from "react";
-import { getSizeClasses, getVariantClasses } from "@/components/Button/buttonStyles";
+import { getFilledStyle, getOutlinedStyle, getSizeClasses } from "./buttonStyles";
 
 const Button = ({
   type = "button",
-  variant = "primary",
+  color,
   size = "large",
+  isFilled = true,
   onClick,
   disabled = false,
-  children = "click!!",
+  children,
   className = "",
 }: ButtonProps) => {
   return (
@@ -16,7 +15,7 @@ const Button = ({
       type={type}
       onClick={onClick}
       disabled={disabled}
-      className={`rounded-xl font-semibold ${getVariantClasses(variant, disabled)} ${getSizeClasses(size)} ${className}`}
+      className={`rounded-xl font-semibold ${color && (isFilled ? getFilledStyle(color, disabled) : getOutlinedStyle(color, disabled))} ${getSizeClasses(size)} ${className} `}
     >
       {children}
     </button>

--- a/src/components/Button/LinkButton.tsx
+++ b/src/components/Button/LinkButton.tsx
@@ -1,12 +1,12 @@
 import Link from "next/link";
-import { ButtonProps } from "@/types/components/button";
-import { getSizeClasses, getVariantClasses } from "./buttonStyles";
+import { getFilledStyle, getOutlinedStyle, getSizeClasses } from "./buttonStyles";
 
 const LinkButton = ({
-  variant = "primary",
+  color,
   size = "large",
+  isFilled = true,
   disabled = false,
-  children = "click!!",
+  children,
   className = "",
   href,
 }: ButtonProps & { href: string }) => {
@@ -14,7 +14,7 @@ const LinkButton = ({
     <Link href={href}>
       <button
         disabled={disabled}
-        className={`rounded-xl font-semibold ${getVariantClasses(variant, disabled)} ${getSizeClasses(size)} ${className}`}
+        className={`rounded-xl font-semibold ${color && (isFilled ? getFilledStyle(color, disabled) : getOutlinedStyle(color, disabled))} ${getSizeClasses(size)} ${className} `}
       >
         {children}
       </button>

--- a/src/components/Button/buttonStyles.ts
+++ b/src/components/Button/buttonStyles.ts
@@ -1,35 +1,36 @@
-// 버튼 색상 (기본 값: 하얀 버튼)
-export const getVariantClasses = (variant: string, disabled: boolean) => {
+export const getFilledStyle = (color: string, disabled?: boolean) => {
   if (disabled) return "bg-gray-400 text-white cursor-not-allowed";
-
-  switch (variant) {
-    case "primary":
-      return "bg-orange-600 text-white hover:opacity-50";
-    case "secondary":
-      return "bg-orange-700 text-white hover:opacity-50";
-    case "tertiary":
-      return "bg-orange-800 text-white hover:opacity-50";
-    case "whitePrimary":
-      return `bg-white text-orange-600 outline outline-orange-600`;
-    case "whiteSecondary":
-      return `bg-white text-orange-700 outline outline-orange-700`;
-    case "whiteTertiary":
-      return `bg-white text-orange-800 outline outline-orange-800`;
+  switch (color) {
+    case "yellow":
+      return "bg-yellow-primary text-gray-800";
+    case "orange":
+      return "bg-orange-primary text-white";
+    case "red":
+      return "bg-red-primary text-white";
     case "disabled":
-      return "bg-white text-gray-400 outline outline-gray-400";
-    default:
-      return "";
+      return "bg-gray-400 text-white";
   }
 };
 
-// 버튼 크기 (기본 값: small)
+export const getOutlinedStyle = (color: string, disabled?: boolean) => {
+  if (disabled) return "bg-white text-gray-400 border border-gray-400 cursor-not-allowed";
+  switch (color) {
+    case "yellow":
+      return "bg-white text-yellow-primary border border-yellow-primary";
+    case "orange":
+      return "bg-white text-orange-primary border border-orange-primary";
+    case "red":
+      return "bg-white text-red-primary border border-red-primary";
+    case "disabled":
+      return "bg-white text-gray-400 border border-gray-400 cursor-not-allowed";
+  }
+};
+
 export const getSizeClasses = (size: string) => {
   switch (size) {
     case "small":
-      return "w-full h-[40px] text-sm";
+      return "h-10 px-4 text-sm w-full";
     case "large":
-      return "w-full h-[44px] text-base";
-    default:
-      return "";
+      return "h-12 px-6 text-base w-full";
   }
 };

--- a/src/types/components/button.d.ts
+++ b/src/types/components/button.d.ts
@@ -1,21 +1,10 @@
-export const variantOptions = {
-  primary: "primary",
-  secondary: "secondary",
-  tertiary: "tertiary",
-  whitePrimary: "whitePrimary",
-  whiteSecondary: "whiteSecondary",
-  whiteTertiary: "whiteTertiary",
-  disabled: "disabled",
-} as const;
-
-export type Variant = keyof typeof variantOptions;
-
-export type ButtonProps = {
+interface ButtonProps {
   type?: "button" | "submit" | "reset";
-  variant?: Variant;
+  color?: "yellow" | "orange" | "red" | "disabled";
   size?: "small" | "large";
+  isFilled?: boolean;
   onClick?: () => void;
   disabled?: boolean;
-  children?: string;
+  children?: React.ReactNode;
   className?: string;
-};
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  safelist: ["bg-yellow-primary", "bg-orange-primary", "bg-red-primary"],
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -14,7 +15,9 @@ const config: Config = {
     extend: {
       colors: {
         "yellow-primary": "#FFE55D",
-        "gray-background-bright": "##F3F4F6",
+        "orange-primary": "#FF9E48",
+        "red-primary": "#FF573B",
+        "gray-background-bright": "#F3F4F6",
         "gray-background": "#F9FAFB",
       },
       backgroundImage: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,7 +17,7 @@ const config: Config = {
         "yellow-primary": "#FFE55D",
         "orange-primary": "#FF9E48",
         "red-primary": "#FF573B",
-        "gray-background-bright": "#F3F4F6",
+        "gray-backgroundBright": "##F3F4F6",
         "gray-background": "#F9FAFB",
       },
       backgroundImage: {


### PR DESCRIPTION
## #️⃣연관된 이슈

> MNM-39

## 📝작업 내용
#### 버튼 수정입니다. 기본적으로 피그마에 존재하는 16가지 버튼은 3가지 속성을 건드리는 걸로 사용가능합니다 (size, color, isfilled) 
####  색상 : (yellow, orange, red, disabled)의 네가지입니다
####  isfilled : (true, false ) -> 내부가 비어있는지
####  크기 : (large, small)
### 색상은 기본값이 존재 하지 않습니다. isfilled의 기본값은 true , size의 기본값은 large 입니다.
### 기존의 16종의 버튼이 아닌 경우
#### 두가지 (color, isfilled)는  속성을 넣지 않고 className에 희망하는 디자인을 넣으면됩니다.
### 모든 버튼은 기본적으로 w-full 입니다 부모에서 사이즈를 지정해주세요


### 스크린샷 (선택)

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a6bc91d4-b16f-47c0-b7b2-69df0fcad4f8">


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
