### PR TITLE
[MNM-59] refactor: popup

### DIFF
--- a/src/app/(sign)/signin/page.tsx
+++ b/src/app/(sign)/signin/page.tsx
@@ -97,7 +97,7 @@ function Login() {
         </Link>
       </div>
       <Popup isOpen={isPopupOpen} onClose={() => setIsPopupOpen(false)}>
-        <div className="flex h-[140px] flex-col justify-between">
+        <div className="flex h-[156px] w-[252px] flex-col items-center justify-between tablet:h-[162px] tablet:w-[402px]">
           <Image
             src="/icons/X.svg"
             width={24}
@@ -107,7 +107,7 @@ function Login() {
             alt="닫기"
           />
           <p className="bold mt-2 text-center text-gray-700">아이디 혹은 비밀번호를 확인해주세요</p>
-          <div className="w-[120px] self-end">
+          <div className="w-[120px] tablet:self-end">
             <Button onClick={() => setIsPopupOpen(false)} size="small" bgColor="yellow">
               확인
             </Button>

--- a/src/app/(testPages)/modal/page.tsx
+++ b/src/app/(testPages)/modal/page.tsx
@@ -6,26 +6,16 @@ import Popup from "@/components/Popup";
 
 export default function Page() {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [isPopupOpen, setIsPopupOpen] = useState<string | null>(null);
 
-  const handleOpenPopup = () => {
-    setIsPopupOpen(true);
-  };
+  const handleOpenModal = () => setIsModalOpen(true);
+  const handleCloseModal = () => setIsModalOpen(false);
 
-  const handleClosePopup = () => {
-    setIsPopupOpen(false);
-  };
+  const handleOpenPopup = (id: string) => setIsPopupOpen(id);
+  const handleClosePopup = () => setIsPopupOpen(null);
 
-  const handleOpenModal = () => {
-    setIsModalOpen(true);
-  };
-
-  const handleCloseModal = () => {
-    setIsModalOpen(false);
-  };
   return (
     <div className="flex h-[100vh] flex-row items-center justify-center">
-      {/* 모달 */}
       <div className="flex gap-4">
         <button
           onClick={handleOpenModal}
@@ -34,13 +24,19 @@ export default function Page() {
           Open Modal
         </button>
         <button
-          onClick={handleOpenPopup}
-          className="rounded-md bg-red-500 px-4 py-2 text-white hover:bg-blue-600"
+          onClick={() => handleOpenPopup("test1")}
+          className="rounded-md bg-red-500 px-4 py-2 text-white hover:bg-red-600"
         >
-          Open Popup
+          Open Popup 1
+        </button>
+        <button
+          onClick={() => handleOpenPopup("test2")}
+          className="rounded-md bg-red-500 px-4 py-2 text-white hover:bg-red-600"
+        >
+          Open Popup 2
         </button>
       </div>
-      {/* props 써야할 것 : title,isOpen,onClose함수,props(모달 컴포넌트 안에 들어갈) */}
+
       <Modal title="하이" isOpen={isModalOpen} onClose={handleCloseModal}>
         <p className="text-gray-700">Modal content goes here!</p>
         <button
@@ -51,29 +47,14 @@ export default function Page() {
         </button>
       </Modal>
 
-      <Popup isOpen={isPopupOpen} onClose={handleClosePopup}>
+      <Popup id="test1" isOpen={isPopupOpen === "test1"} onClose={handleClosePopup}>
         <h2 className="mb-4 text-lg font-semibold">프롭스 제목이구여</h2>
-        <p className="text-gray-700">이건 내용입니다.</p>
-        <div>
-          <input type="text" placeholder="ㅎㅇ" />
-          <button>버튼!</button>
-        </div>
-        <div>
-          <input type="text" placeholder="ㅎㅇ" />
-          <button>버튼!</button>
-        </div>
-        <div>
-          <input type="text" placeholder="ㅎㅇ" />
-          <button>버튼!</button>
-        </div>
-        <div className="">
-          <input type="text" placeholder="ㅎㅇ" />
-          <button>버튼!</button>
-          <button>버튼!</button>
-          <button>버튼!</button>
-          <button>버튼!</button>
-          <button>버튼!</button>
-        </div>
+        <p className="text-gray-700">테스트1</p>
+      </Popup>
+
+      <Popup id="test2" isOpen={isPopupOpen === "test2"} onClose={handleClosePopup}>
+        <h2 className="mb-4 text-lg font-semibold">프롭스 제목이구여</h2>
+        <p className="text-gray-700">테스트2</p>
       </Popup>
     </div>
   );

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -5,7 +5,7 @@ import { PopupProps } from "@/types/components/modalPopup";
 
 const popupControls: { [key: string]: (isOpen: boolean) => void } = {};
 
-export default function Popup({ id, isOpen, onClose, children }: PopupProps) {
+export default function Popup({ id, isOpen, onClose, children, className }: PopupProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const controlRef = useRef(() => onClose());
 
@@ -42,7 +42,7 @@ export default function Popup({ id, isOpen, onClose, children }: PopupProps) {
       className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
       onClick={handleClickOutside}
     >
-      <div className="relative w-96 rounded-lg bg-white p-6 shadow-lg" ref={modalRef}>
+      <div className={`relative rounded-lg bg-white p-6 shadow-lg ${className} `} ref={modalRef}>
         {children}
       </div>
     </div>

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -3,8 +3,11 @@
 import React, { useEffect, useRef } from "react";
 import { PopupProps } from "@/types/components/modalPopup";
 
-export default function Popup({ isOpen, onClose, children }: PopupProps) {
+const popupControls: { [key: string]: (isOpen: boolean) => void } = {};
+
+export default function Popup({ id, isOpen, onClose, children }: PopupProps) {
   const modalRef = useRef<HTMLDivElement>(null);
+  const controlRef = useRef(() => onClose());
 
   useEffect(() => {
     const handleEsc = (event: KeyboardEvent) => {
@@ -17,10 +20,14 @@ export default function Popup({ isOpen, onClose, children }: PopupProps) {
       document.addEventListener("keydown", handleEsc);
     }
 
+    if (id) {
+      popupControls[id] = controlRef.current;
+    }
+
     return () => {
       document.removeEventListener("keydown", handleEsc);
     };
-  }, [isOpen, onClose]);
+  }, [isOpen, onClose, id]);
 
   const handleClickOutside = (event: React.MouseEvent<HTMLDivElement>) => {
     if (modalRef.current && !modalRef.current.contains(event.target as Node)) {

--- a/src/types/components/modalPopup.d.ts
+++ b/src/types/components/modalPopup.d.ts
@@ -2,6 +2,7 @@ export interface PopupProps {
   isOpen: boolean;
   onClose: () => void;
   children: React.ReactNode;
+  id?: string;
 }
 
 export interface ModalProps extends PopupProps {

--- a/src/types/components/modalPopup.d.ts
+++ b/src/types/components/modalPopup.d.ts
@@ -3,6 +3,7 @@ export interface PopupProps {
   onClose: () => void;
   children: React.ReactNode;
   id?: string;
+  className?: string;
 }
 
 export interface ModalProps extends PopupProps {


### PR DESCRIPTION
## #️⃣연관된 이슈

> MNM-59

##팝업이 크기가 다 달라지는거같아서 필수적으로 팝업 내부에 크기 지정해줘야 합니다.

## 📝작업 내용

> Popup 수정했습니다.
> 사용시. id값과 isPopupOpen 을 검증해서 맞는 popup을 불러옵니다.
> 예시 코드입니다.

```js
const [isPopupOpen, setIsPopupOpen] = useState<string | null>(null);
// ....
    if (errorMessage === "중복된 이메일입니다") {
      setIsPopupOpen("email-exists");
// ....
      <Popup
        id="email-exists"
        isOpen={isPopupOpen === "email-exists"}
        onClose={() => setIsPopupOpen(null)}
      >
        <div className="flex h-[156px] w-[252px] flex-col items-center justify-between tablet:h-[162px] tablet:w-[402px]">
          <Image
          src="/icons/X.svg"
          width={24}
          height={24}
          className="self-end"
          onClick={() => setIsPopupOpen(null)}
          alt="닫기"
          />
          <p className="bold mt-2 text-center text-gray-700">이메일이 존재합니다.</p>
          <div className="w-[120px] tablet:self-end">
            <Button onClick={() => setIsPopupOpen(null)} size="small" bgColor="yellow">
              확인
            </Button>
          </div>
        </div>
      </Popup>
```

### 스크린샷 (선택)

<img width="297" alt="image" src="https://github.com/user-attachments/assets/1498f777-6a0b-41b3-916b-e6df6cd05a5b">
<img width="305" alt="image" src="https://github.com/user-attachments/assets/0d46c57f-9a6f-4be9-a499-9c1c245b9dd5">

<img width="288" alt="image" src="https://github.com/user-attachments/assets/20df1b13-55bc-4ecb-8d38-cfeca7f506d6">




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
