### PR TITLE
[MNM-60]feat: location 변경 함수 추가

### DIFF
--- a/src/apis/gatheringsApi.ts
+++ b/src/apis/gatheringsApi.ts
@@ -1,3 +1,4 @@
+import { getRegionMapping } from "@/hooks/useRegion";
 import {
   CreateGathering,
   GatheringRes,
@@ -8,6 +9,7 @@ import {
   GetMyJoinedGatherings,
   GetMyJoinedGatheringsRes,
 } from "@/types/api/gatheringApi";
+import { DistrictName } from "@/types/hooks/region";
 import fetchInstance from "./fetchInstance";
 
 // 모임 취소
@@ -28,7 +30,9 @@ export async function getGatherings(params: Gatherings) {
 export async function createGathering(body: CreateGathering) {
   const formData = new FormData();
   Object.entries(body).forEach(([key, value]) => {
-    if (Array.isArray(value)) {
+    if (key === "location") {
+      formData.append(key, getRegionMapping(value as DistrictName));
+    } else if (Array.isArray(value)) {
       value.forEach(item => formData.append(key, item));
     } else if (value !== undefined && value !== null) {
       formData.append(key, value.toString());

--- a/src/app/(testPages)/(apis)/testgathering/page.tsx
+++ b/src/app/(testPages)/(apis)/testgathering/page.tsx
@@ -46,7 +46,7 @@ export default function GatheringTestPage() {
     try {
       const gatheringData: CreateGathering = {
         type: "RESTAURANT",
-        location: "서울 강남구",
+        location: "제주특별자치도",
         name: "맛집 팀방",
         dateTime: "2024-12-02T07:06:02.489",
         capacity: 10,

--- a/src/hooks/useRegion.ts
+++ b/src/hooks/useRegion.ts
@@ -1,0 +1,20 @@
+import { DistrictName, RegionName } from "@/types/hooks/region";
+
+export const REGION_STRUCTURE: Record<RegionName, DistrictName[]> = {
+  SEOUL: ["서울"],
+  GYEONGGI_DO: ["경기", "인천"],
+  GANGWON_DO: ["강원"],
+  CHUNGCHEONG_DO: ["충북", "충남", "대전", "세종"],
+  GYEONGSANG_DO: ["경북", "경남", "대구", "부산", "울산"],
+  JEOLLA_DO: ["전북", "전남", "광주"],
+  JEJU_ISLAND: ["제주특별자치도"],
+};
+
+export const getRegionMapping = (selectedRegion: DistrictName): RegionName => {
+  for (const [region, districts] of Object.entries(REGION_STRUCTURE)) {
+    if (districts.includes(selectedRegion as DistrictName)) {
+      return region as RegionName;
+    }
+  }
+  return selectedRegion as RegionName;
+};

--- a/src/types/hooks/region.d.ts
+++ b/src/types/hooks/region.d.ts
@@ -1,0 +1,26 @@
+export type RegionName =
+  | "SEOUL"
+  | "GYEONGGI_DO"
+  | "GANGWON_DO"
+  | "CHUNGCHEONG_DO"
+  | "GYEONGSANG_DO"
+  | "JEOLLA_DO"
+  | "JEJU_ISLAND";
+export type DistrictName =
+  | "서울"
+  | "경기"
+  | "인천"
+  | "강원"
+  | "충북"
+  | "충남"
+  | "대전"
+  | "세종"
+  | "경북"
+  | "경남"
+  | "대구"
+  | "부산"
+  | "울산"
+  | "전북"
+  | "전남"
+  | "광주"
+  | "제주특별자치도";


### PR DESCRIPTION
## #️⃣연관된 이슈

> MNM-60

## 📝작업 내용

> location 을 자동으로 저희가 고른 7개로 변경해서 보내주는 함수입니다.
> 17종류로 오며(daumapi 기준) 각각에 배치해서 보내줍니다.

### 스크린샷 (선택)

<img width="414" alt="image" src="https://github.com/user-attachments/assets/8977dcef-e069-4677-8945-d2421c785f91">


## 💬리뷰 요구사항(선택)

> 테스트 할때는 잘 가는데요 혹시  안되는거 있으면 말해주세요
