### PR TITLE
[MNM-98] refactor: 프로필 드롭다운 닫힘 기능 추가

### DIFF
--- a/src/components/Gnb.tsx
+++ b/src/components/Gnb.tsx
@@ -26,6 +26,10 @@ export default function Gnb() {
     window.location.href = "/";
   };
 
+  const handleMenuClose = () => {
+    setIsMenuOpen(false); // 드롭다운 닫기
+  };
+
   return (
     <header>
       <div className="tablet:h-15 fixed top-0 z-30 flex h-[60px] w-full items-center justify-center bg-yellow-primary text-black">
@@ -81,6 +85,7 @@ export default function Gnb() {
                 <Link
                   href={"/mypage"}
                   className="inline-block h-10 py-[10px] pl-3 text-sm tablet:h-11 tablet:pl-4 tablet:text-base"
+                  onClick={handleMenuClose}
                 >
                   마이페이지
                 </Link>


### PR DESCRIPTION
## #️⃣연관된 이슈

> [MNM-98]

## 📝작업 내용

> 기존 : 로그인 후 GNB 프로필 버튼 클릭 시 드롭다운 표시 -> 마이페이지 이동 시 드롭다운 여전히 열려있음.
> 수정 : 마이페이지 이동 시 드롭다운 닫힘

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


[MNM-98]: https://daremfit.atlassian.net/browse/MNM-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ