### PR TITLE
[MNM-112]refactor: 모임목록,찜한모임 캐싱

### DIFF
--- a/src/app/(home)/_components/ButtonJoin.tsx
+++ b/src/app/(home)/_components/ButtonJoin.tsx
@@ -2,11 +2,21 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { joinGathering } from "@/apis/assignGatheringApi";
 import useUserStore from "@/store/userStore";
 
-export default function ButtonJoin({ id, participation }: { id: number; participation: boolean }) {
+export default function ButtonJoin({
+  id,
+  participation,
+  onUpdate,
+}: {
+  id: number;
+  participation: boolean;
+  onUpdate: () => void;
+}) {
   const [isParticipation, setIsParticipation] = useState(participation);
-  const { id: userId } = useUserStore();
+  const [, setToast] = useState(false);
+  const { id: userId } = useUserStore(); // 로그인 상태 확인
   const router = useRouter();
 
   async function handleJoinGathering() {
@@ -15,30 +25,11 @@ export default function ButtonJoin({ id, participation }: { id: number; particip
         router.push("/signin");
         return;
       }
-
-      // 쿠키에서 accessToken 가져오기
-      const cookies = document.cookie;
-      const token = cookies
-        .split("; ")
-        .find(row => row.startsWith("accessToken="))
-        ?.split("=")[1];
-
-      // API 요청
-      const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/gatherings/${id}/join`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        credentials: "include",
-      });
-
-      if (!response.ok) {
-        router.push("/signin");
-      }
-
+      joinGathering(id);
       alert("모임을 참여했습니다! 🎉");
       setIsParticipation(true);
+      onUpdate();
+      setToast(true);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "알 수 없는 에러가 발생했습니다.";
@@ -55,7 +46,14 @@ export default function ButtonJoin({ id, participation }: { id: number; particip
 
   return (
     <div>
-      {isParticipation ? (
+      {!userId ? ( // 로그인 안 되어 있으면 무조건 참여하기만 보여줌
+        <button
+          onClick={() => router.push("/signin")}
+          className="h-[40px] w-[100px] rounded-xl border bg-yellow-primary text-black"
+        >
+          참여하기
+        </button>
+      ) : isParticipation ? ( // 로그인 상태에서 참여 여부 확인
         <div className="flex h-[40px] w-[100px] items-center rounded-xl border bg-gray-400 px-5 text-base font-semibold text-gray-100">
           참여완료
         </div>

--- a/src/app/(home)/_components/Card.tsx
+++ b/src/app/(home)/_components/Card.tsx
@@ -7,9 +7,15 @@ import { GetGathering } from "@/types/components/card";
 import { formatToOriginTime, getRemainingOriginHours } from "@/utils/date";
 import ButtonJoin from "./ButtonJoin";
 
-export default function Card({ cardData }: { cardData: GetGathering }) {
+export default function Card({
+  cardData,
+  onUpdate,
+}: {
+  cardData: GetGathering;
+  onUpdate: () => void;
+}) {
   return (
-    <div className="border-gray relative flex w-full transform flex-col rounded-2xl border-y-2 bg-gray-background transition-transform duration-200 hover:shadow-xl tablet:h-[156px] tablet:w-full tablet:flex-row">
+    <div className="border-gray relative flex w-full transform flex-col rounded-2xl border-y-2 bg-white transition-transform duration-200 hover:shadow-xl tablet:h-[156px] tablet:w-full tablet:flex-row">
       {/* 카드 내용 */}
       <Link prefetch={false} href={`groupDetail/${cardData.id}`} className="relative flex">
         <Image
@@ -21,9 +27,9 @@ export default function Card({ cardData }: { cardData: GetGathering }) {
           alt="food"
           width={272}
           height={153}
-          className="w-full rounded-l-2xl object-cover tablet:h-[153px] tablet:w-[272px]"
+          className="w-full rounded-2xl object-cover tablet:h-[153px] tablet:w-[272px] tablet:rounded-l-2xl"
         />
-        <div className="absolute right-0 top-0 flex flex-row items-center gap-1 rounded-bl-xl border border-none bg-yellow-primary px-2 py-1">
+        <div className="absolute right-0 top-0 flex flex-row items-center gap-1 rounded-xl border border-none bg-yellow-primary px-2 py-1 tablet:rounded-bl-xl">
           <Image src="/images/mainPage/alarm.svg" width={20} height={16} alt="alarm" />
           <p>{getRemainingOriginHours(cardData.registrationEnd) || "날짜 없음"}</p>
         </div>
@@ -83,7 +89,7 @@ export default function Card({ cardData }: { cardData: GetGathering }) {
             </div>
             <Progressbar now={cardData.participantCount} max={cardData.capacity} />
           </div>
-          <ButtonJoin id={cardData.id} participation={cardData.participation} />
+          <ButtonJoin id={cardData.id} participation={cardData.participation} onUpdate={onUpdate} />
         </div>
       </div>
     </div>

--- a/src/app/(home)/_components/CreateGathering.tsx
+++ b/src/app/(home)/_components/CreateGathering.tsx
@@ -39,7 +39,7 @@ export default function CreateGathering({
     setValue,
     watch,
     trigger,
-    formState: { errors, touchedFields, isSubmitted },
+    formState: { errors, touchedFields, isSubmitted, isValid },
   } = useForm<CreateGatheringFormData>({
     resolver: zodResolver(CreateGatheringSchema),
     defaultValues: {
@@ -261,7 +261,6 @@ export default function CreateGathering({
               </div>
             ))}
           </div>
-          {errors.dateTime && <p className="text-red-500">{errors.dateTime.message}</p>}
         </div>
 
         {/* 모집 정원 */}
@@ -380,7 +379,11 @@ export default function CreateGathering({
           </div>
         </div>
 
-        <Button type="submit" bgColor="disabled" className="py-2 hover:bg-yellow-primary">
+        <Button
+          type="submit"
+          bgColor={`${isValid ? "yellow" : "disabled"}`}
+          className={`py-2 hover:bg-yellow-primary ${isValid ? "border-green-500" : "bg-gray-300"}`}
+        >
           확인
         </Button>
       </form>

--- a/src/app/(home)/_components/GatheringClient.tsx
+++ b/src/app/(home)/_components/GatheringClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef } from "react";
 import { useSearchParams } from "next/navigation";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { getGatherings } from "@/apis/searchGatheringApi";
 import Card from "@/app/(home)/_components/Card";
 import CardSkeleton from "@/app/(home)/_components/Skeleton/SKCard";
@@ -11,6 +11,8 @@ import { GetGathering } from "@/types/components/card";
 type GatheringFilters = Record<string, string | number | null>;
 
 export default function GatheringClient() {
+  const queryClient = useQueryClient();
+
   const searchParams = useSearchParams();
 
   // 필터 메모이제이션
@@ -29,14 +31,21 @@ export default function GatheringClient() {
 
   // React Query의 useInfiniteQuery를 사용한 페이지네이션 및 캐싱
   const { data, fetchNextPage, hasNextPage, isFetching, isLoading } = useInfiniteQuery({
-    queryKey: ["gatherings", filters], // 필터를 queryKey로 사용해 캐싱 구분
+    queryKey: ["gatherings", filters], // queryKey 통일
     queryFn: async ({ pageParam = 0 }) => {
       const result = await getGatherings({ ...filters, page: pageParam });
-      return { data: result, nextPage: result.length > 0 ? pageParam + 1 : undefined };
+
+      // API 응답 데이터의 모든 favorite 값을 true로 강제 설정
+      return {
+        data: result.map(gathering => ({ ...gathering })),
+        nextPage: result.length > 0 ? pageParam + 1 : undefined,
+      };
     },
     initialPageParam: 0, // 첫 페이지 초기값
     getNextPageParam: lastPage => lastPage.nextPage, // 다음 페이지 설정
-    staleTime: 5 * 60 * 1000, // 캐시 만료 시간 5분
+    refetchOnMount: "always",
+    staleTime: 0,
+    refetchOnWindowFocus: true, // 윈도우 포커스 시 새로고침
   });
 
   // IntersectionObserver로 무한 스크롤 구현
@@ -54,6 +63,10 @@ export default function GatheringClient() {
     if (observerRef.current) observer.observe(observerRef.current);
     return () => observer.disconnect();
   }, [fetchNextPage, hasNextPage, isFetching]);
+
+  const handleUpdate = () => {
+    queryClient.refetchQueries({ queryKey: ["favoriteGathering"] });
+  };
 
   // 데이터 병합 및 중복 제거
   const allData = Array.from(
@@ -81,7 +94,7 @@ export default function GatheringClient() {
   return (
     <div className="gathering-list my-6 flex flex-col gap-3">
       {allData.map((gathering: GetGathering) => (
-        <Card key={gathering.id} cardData={gathering} />
+        <Card key={gathering.id} cardData={gathering} onUpdate={handleUpdate} />
       ))}
       {isFetching &&
         Array.from({ length: 4 }).map((_, index) => <CardSkeleton key={`skeleton-${index}`} />)}


### PR DESCRIPTION
## #️⃣연관된 이슈

#112 MNM-112

## 📝작업 내용
#### 모임생성
- 달력에 유호하지 않은 날짜 막기 (zod사용으로 유효성 검사) (현재보다 늦은 시간 , +61일)
- 입력 인풋들이 정상화 된 값이면 확인버튼 활성화(bg-yellow-primary)

#### 메인페이지
- 참여하기,찜하기 버튼(캐싱 오류) 수정 (boolean상태가 적용 안되는 문제)
- 참여하기 미로그인 시 로그인페이지 다이렉트
- 메인페이지 카드컴포넌트 bg-white로 변경



### 스크린샷 (선택)
<div align="center"> <img src="https://github.com/user-attachments/assets/28490dc2-58cb-4092-87bf-da1b87353114" alt="스크린샷 1" width="45%" /> <img src="https://github.com/user-attachments/assets/a4c78ce5-0d7d-4740-bc53-9ac66e207638" alt="스크린샷 2" width="45%" /> </div> <div align="center"> <img src="https://github.com/user-attachments/assets/f0d7fe28-ca3d-4d9a-ad7b-91cf98b8e53b" alt="스크린샷 3" width="45%" /> <img src="https://github.com/user-attachments/assets/b70a3e19-513e-49e9-8108-ca6dc0a7fc1e" alt="스크린샷 4" width="45%" /> </div>




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
