### PR TITLE
[MNM-126]fix: 모임생성 키워드

### DIFF
--- a/src/__tests__/unit/pages/gatherings/createGath.test.ts
+++ b/src/__tests__/unit/pages/gatherings/createGath.test.ts
@@ -1,5 +1,5 @@
-import { CreateGatheringFormData } from "@/hooks/CreateGathering/formHandler";
 import { CreateGatheringSchema } from "@/utils/createGathSchema";
+import { CreateGatheringFormData } from "@/utils/formHandler";
 
 describe("CreateGatheringSchema", () => {
   const validData: CreateGatheringFormData = {

--- a/src/app/(home)/_components/CreateGathering.tsx
+++ b/src/app/(home)/_components/CreateGathering.tsx
@@ -4,19 +4,19 @@ import { useEffect, useState } from "react";
 import Image from "next/image";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import {
-  CreateGatheringFormData,
-  handleKeywordAdditionTest,
-  handleKeywordChange,
-  handleKeywordDelete,
-  handleSubmitToServer,
-} from "@/hooks/CreateGathering/formHandler";
 import Button from "@/components/Button/Button";
 import Calendar from "@/components/Calendar/Calendar";
 import Kakao from "@/components/Kakaomap/Kakao";
 import Modal from "@/components/Modal";
 import useDateStore from "@/store/dateStore";
 import { CreateGatheringSchema } from "@/utils/createGathSchema";
+import {
+  CreateGatheringFormData,
+  handleKeywordAddition,
+  handleKeywordChange,
+  handleKeywordDelete,
+  handleSubmitToServer,
+} from "@/utils/formHandler";
 import { categoryList, timeChips } from "../../../constants/categoryList";
 import { Input } from "./Input";
 
@@ -145,9 +145,9 @@ export default function CreateGathering({
         {/* 이미지 업로드 */}
         <div className="flex flex-col gap-1">
           <p>이미지</p>
-          <div className="flex flex-row gap-2">
+          <div className="flex flex-row items-center gap-2">
             {/* 파일 이름 표시 */}
-            <div className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap rounded-lg border border-gray-100 bg-gray-100 px-2 py-2 text-gray-400">
+            <div className="relative flex-1 overflow-hidden text-ellipsis whitespace-nowrap rounded-lg border border-gray-100 bg-gray-100 px-2 py-2 text-gray-400">
               {(() => {
                 // 브라우저 환경 확인 후 파일 정보 접근
                 if (typeof window !== "undefined") {
@@ -156,12 +156,26 @@ export default function CreateGathering({
                 }
                 return "이미지를 첨부해주세요";
               })()}
+              {/* X 버튼 */}
+              {watch("image") && (
+                <button
+                  type="button"
+                  className="absolute right-2 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full bg-gray-200 text-white hover:bg-gray-500"
+                  onClick={() => {
+                    setValue("image", null); // 파일 초기화
+                  }}
+                >
+                  &times;
+                </button>
+              )}
             </div>
+
+            {/* 파일 인풋 (숨김) */}
             <input
               type="file"
               id="fileInput"
               accept="image/*"
-              className="hidden border"
+              className="hidden"
               onChange={e => {
                 const files = e.target.files;
                 if (files && files[0]) {
@@ -191,6 +205,7 @@ export default function CreateGathering({
               파일 찾기
             </button>
           </div>
+
           {errors.image && <p className="text-red-500">{errors.image.message}</p>}
         </div>
 
@@ -331,14 +346,14 @@ export default function CreateGathering({
 
         {/* 키워드 */}
         <div className="flex flex-col gap-1 pb-4 font-medium">
-          <div className="flex flex-row items-center gap-2">
+          <div className="mb-2 flex flex-row flex-wrap items-center gap-2">
             <p>관련 해시태그</p>
             {/* 키워드 리스트 */}
-            <div className="flex h-[30px] flex-row items-center gap-1">
+            <div className="flex flex-row flex-wrap items-center gap-1">
               {keywords.map((word, index) => (
                 <div
                   key={index}
-                  className="text- group relative flex items-center rounded-xl border bg-yellow-200 px-2 py-1"
+                  className="group relative flex items-center rounded-xl border bg-yellow-200 px-2 py-1"
                 >
                   {word}
                   {/* X표시: 기본 hidden, 그룹 호버 시 나타남 */}
@@ -366,12 +381,7 @@ export default function CreateGathering({
               onKeyDown={e => {
                 if (e.key === " ") {
                   e.preventDefault();
-                  handleKeywordAdditionTest(
-                    e.currentTarget.value,
-                    keywords,
-                    setKeywordValue,
-                    setValue,
-                  );
+                  handleKeywordAddition(e.currentTarget.value, keywords, setKeywordValue, setValue);
                 }
               }}
               className="w-full rounded-lg border p-2"

--- a/src/utils/formHandler.ts
+++ b/src/utils/formHandler.ts
@@ -117,8 +117,8 @@ export const handleKeywordChange = (
 ) => {
   setKeywordInput(value);
 };
-
-export const handleKeywordAdditionTest = (
+//키워드 추가 함수
+export const handleKeywordAddition = (
   value: string,
   keywords: string[],
   setKeywordValue: React.Dispatch<string>,
@@ -135,28 +135,6 @@ export const handleKeywordAdditionTest = (
     if (!keywords.includes(newKeyword)) {
       setValue("keyword", [...keywords, newKeyword]); // React Hook Form 상태 업데이트
     }
-  }
-};
-
-// 키워드 추가 핸들러 함수
-export const handleKeywordAddition = (
-  value: string,
-  setFormData: Dispatch<SetStateAction<CreateGatheringFormData>>,
-  setKeywordInput: Dispatch<SetStateAction<string>>,
-) => {
-  if (value.endsWith(" ") && value.startsWith("#")) {
-    const newKeyword = value.trim().slice(1); // '#' 제거 후 공백 제거
-
-    // 빈 키워드 방지: newKeyword가 공백 또는 빈 문자열이면 추가하지 않음
-    if (newKeyword.length === 0) {
-      setKeywordInput(""); // 입력 필드 초기화만 수행
-      return;
-    }
-    setFormData(prev => ({
-      ...prev,
-      keyword: [...(prev.keyword || []), newKeyword],
-    }));
-    setKeywordInput(""); // 입력 필드 초기화
   }
 };
 
@@ -181,6 +159,9 @@ export const handleSubmitToServer = async (
   Object.entries(data).forEach(([key, value]) => {
     if (key === "image" && value instanceof File) {
       formDataToSend.append(key, value); // File 객체 추가
+    } else if (key === "keyword" && Array.isArray(value)) {
+      // keyword를 배열 그대로 추가
+      formDataToSend.append(key, value.join(",")); // 콤마로 구분된 문자열로 변환
     } else if (value !== null && value !== undefined) {
       formDataToSend.append(key, Array.isArray(value) ? JSON.stringify(value) : String(value));
     }
@@ -192,7 +173,6 @@ export const handleSubmitToServer = async (
       body: formDataToSend,
     });
     if (!response.ok) throw new Error("서버 응답 오류!");
-
     alert("모임이 성공적으로 생성되었습니다!");
     setIsOpen(false);
   } catch (error) {


### PR DESCRIPTION
## #️⃣연관된 이슈

[MNM-126]

## 📝작업 내용

### 모임생성

-  키워드 UI
-  formHandler 수정 (키워드 따옴표 이슈 수정)
       1.기존 : '[''차슈라멘'',''미소라멘'']'
       2.현재:   ['차슈라멘','미소라멘']
- - 이미지파일 취소 버튼 기능구현 (호버 시 진한 색 bg-gray-500)
- formHandler.ts 위치 변경 (hooks-> utils)

### 해시태그

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/34a07db3-6925-4eab-a22a-7cfc317b3ff4" alt="이미지1" width="400"></td>
    <td><img src="https://github.com/user-attachments/assets/385f6bbe-7a59-4ff8-95ad-f4276f50729e" alt="이미지2" width="400"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/d793a014-b3b6-4243-9ce3-71b1862d4916" alt="이미지3" width="400"></td>
    <td><img src="https://github.com/user-attachments/assets/2e9fb64f-3f71-434d-99c1-c877abf5853e" alt="이미지4" width="400"></td>
  </tr>
</table>

### 이미지 취소 버튼

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/7b8c667a-6db2-488d-9d04-f728c3573ff5" alt="이미지1" width="400"></td>
    <td><img src="https://github.com/user-attachments/assets/d7f7e0a0-2f7f-43e4-9ae3-b733312f3324" alt="이미지2" width="400"></td>
  </tr>
</table>

### 모임상세페이지의 키워드 결과


![스크린샷 2024-12-27 오후 9 55 17](https://github.com/user-attachments/assets/656634a7-dda6-446f-a45a-29740907cca9)


[MNM-126]: https://daremfit.atlassian.net/browse/MNM-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ